### PR TITLE
I had to switch versions in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
-      <dependency>
-          <groupId>com.splicemachine</groupId>
-          <artifactId>splice-hibernate-dialect</artifactId>
-          <version>2.7.0.1742-SNAPSHOT</version>
-      </dependency>
+    <dependency>
+      <groupId>com.splicemachine</groupId>
+      <artifactId>splice-hibernate-dialect</artifactId>
+      <version>2.6.0.1726-SNAPSHOT</version>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-thymeleaf</artifactId>


### PR DESCRIPTION
To get this to install on my clean machine, I had to modify `pom.xml` to use a different version of `splice-hibernate-dialect`.

I found these two in my repository cache:
```
 ~/.m2/repository/com/splicemachine/splice-hibernate-dialect/2.6.0.1726-SNAPSHOT
 ~/.m2/repository/com/splicemachine/splice-hibernate-dialect/2.7.0.1742-SNAPSHOT
```

There are no artifacts in `2.7.0.1742-SNAPSHOT`. So I switched the PetClinic `pom.xml` to point to `2.6.0.1726-SNAPSHOT`:

From:
```
<dependency>
  <groupId>com.splicemachine</groupId>
  <artifactId>splice-hibernate-dialect</artifactId>
  <version>2.7.0.1742-SNAPSHOT</version>
</dependency>
```

To:
```
<dependency>
  <groupId>com.splicemachine</groupId>
  <artifactId>splice-hibernate-dialect</artifactId>
  <version>2.6.0.1726-SNAPSHOT</version>
</dependency>
```