### PR TITLE
issue/DBAAS-1135

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:alpine
+MAINTAINER Nikhil Nygaard <nnygaard@splicemachine.com>
+
+# Spring Boot application creates working directories for Tomcat by default
+VOLUME /tmp
+ADD ./target/spring-petclinic-1.5.1.jar petclinic.jar
+
+RUN sh -c 'touch /petclinic.jar'
+
+RUN apk --no-cache add curl
+
+# To reduce Tomcat startup time we added a system property pointing to "/dev/urandom" as a source of entropy.
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/petclinic.jar"]

--- a/mvnw
+++ b/mvnw
@@ -226,6 +226,12 @@ export MAVEN_CMD_LINE_ARGS
 
 WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
+echo "$JAVACMD" \
+  $MAVEN_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CMD_LINE_ARGS
+
 exec "$JAVACMD" \
   $MAVEN_OPTS \
   -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,10 @@
 
 ###### A fork of [spring-projects](https://github.com/spring-projects/spring-petclinic) PetClinic
 
+Updated Build Environment Configuration Documentation [specific to SpliceMachine][1] new developers.
+
+[1]: https://splicemachine.atlassian.net/wiki/spaces/~nnygaard/pages/115507299/Configure+Build+Environment
+
 ## Understanding the Spring Petclinic application with a few diagrams
 <a href="https://speakerdeck.com/michaelisvy/spring-petclinic-sample-application">See the presentation here</a>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.datasource.schema=classpath*:db/${database}/schema.sql
 spring.datasource.data=classpath*:db/${database}/data.sql
 
 
-spring.datasource.url=jdbc:splice://localhost:1527/splicedb;user=splice;password=admin
+spring.datasource.url=jdbc:splice://docker.for.mac.localhost:1527/splicedb;user=splice;password=admin
 spring.datasource.username=splice
 spring.datasource.password=admin
 spring.datasource.driver-class-name=com.splicemachine.db.jdbc.ClientDriver

--- a/src/main/resources/db/mysql/schema.sql
+++ b/src/main/resources/db/mysql/schema.sql
@@ -4,7 +4,7 @@ ALTER DATABASE petclinic
   DEFAULT CHARACTER SET utf8
   DEFAULT COLLATE utf8_general_ci;
 
-GRANT ALL PRIVILEGES ON petclinic.* TO pc@localhost IDENTIFIED BY 'pc';
+GRANT ALL PRIVILEGES ON petclinic.* TO pc@docker.for.mac.localhost IDENTIFIED BY 'pc';
 
 USE petclinic;
 

--- a/src/main/resources/db/splicemachine/schema.sql
+++ b/src/main/resources/db/splicemachine/schema.sql
@@ -1,3 +1,18 @@
+
+/*
+  DBAAS-1135 - Baseline Spring Implementation (PetClinic)
+  This is a workaround because I was unable to get "IF NOT EXISTS" to work with the
+  SpliceMachine grammar. Drop the tables before making them.
+*/
+
+DROP TABLE visits IF EXISTS;
+DROP TABLE pets IF EXISTS;
+DROP TABLE owners IF EXISTS;
+DROP TABLE types IF EXISTS;
+DROP TABLE vet_specialties IF EXISTS;
+DROP TABLE specialties IF EXISTS;
+DROP TABLE vets IF EXISTS;
+
 CREATE TABLE vets (
   id         INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
   first_name VARCHAR(30),


### PR DESCRIPTION
@MurrayBrown linking me to the public Splice Jira pointed me to this tidbit:
```
Drop table [table_name] if exists - works as expected
Drop table if exists [table_name] - doesn't drop table
```
https://splice.atlassian.net/browse/SPLICE-1816?jql=text%20~%20%22%5C%22IF%20NOT%20EXISTS%5C%22%22

So I flipped the order of the `if exists` and we're okay now. PetClinic starts with or without the tables.